### PR TITLE
Updated travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 # command to install dependencies
 # Use sdist and pip install to test a distribution tarball
 install: "python setup.py sdist; find ./dist/ -iname *.tar.gz | xargs pip install"


### PR DESCRIPTION
* The charting module improts seaborn, althought it doesn't use it.
  I am assuming that seaborn may be used in the future. Seaborn
  requires importlib, which is not part of the Python Standard
  Library in Python 2.6, so I am removing 2.6 from the travis
  file so that higher versions are installed.

  I could have gone with a conditional install, but it seemed like
  it was more trouble than it was worth. I could have also just
  removed the seaborn dependency, but since I am not the maintainer
  I will leave that decision to him. If the decision is made to
  remove the seaborn depencdency then support for Python 2.6 can
  be added back.